### PR TITLE
Fixes for KhronosGroup/glTF-Blender-IO#387

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_sampler_keyframes.py
@@ -203,6 +203,10 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
 
         start_frame = min([channel.range()[0] for channel in channels  if channel is not None])
         end_frame = max([channel.range()[1] for channel in channels  if channel is not None])
+
+        if export_settings[gltf2_blender_export_keys.FRAME_RANGE]:
+            start_frame = max(bake_range_start, start_frame)
+            end_frame = min(bake_range_end, end_frame)
     else:
         start_frame = bake_range_start
         end_frame = bake_range_end
@@ -225,7 +229,9 @@ def gather_keyframes(blender_object_if_armature: typing.Optional[bpy.types.Objec
         frame = start_frame
         step = export_settings['gltf_frame_step']
         while frame <= end_frame:
-            key = Keyframe(channels, frame, bake_channel)
+            # gltf2 expects time to start at 0 whereas Blender defaults to frame 1.
+            adjusted_frame = frame - start_frame
+            key = Keyframe(channels, adjusted_frame, bake_channel)
             if isinstance(pose_bone_if_armature, bpy.types.PoseBone):
 
                 mat = get_bone_matrix(

--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_animation_samplers.py
@@ -42,6 +42,17 @@ def gather_animation_sampler(channels: typing.Tuple[bpy.types.FCurve],
                              export_settings
                              ) -> gltf2_io.AnimationSampler:
 
+    if blender_object.animation_data and blender_object.animation_data.nla_tracks and export_settings[gltf2_blender_export_keys.FRAME_RANGE]:
+      # Attempt to adjust the bake range to match the nla track strip that matches the action_name.
+      for track in blender_object.animation_data.nla_tracks:
+        if not track.strips:
+          continue
+        for strip in track.strips:
+          if strip.name == action_name:
+            bake_range_start = strip.frame_start
+            bake_range_end = strip.frame_end
+            break
+
     blender_object_if_armature = blender_object if blender_object.type == "ARMATURE" else None
     if blender_object_if_armature is not None and driver_obj is None:
         if bake_bone is None:


### PR DESCRIPTION
1. Fixes mismatch between Blender starting frame and gltf2 expectation that animations always start at time 0.
2. Applies the FRAME_RANGE option.